### PR TITLE
Bugfix lwdev 6212 speed up redis cleanup operations

### DIFF
--- a/src/Lykke.Job.CandleHistoryWriter.Repositories/Candles/CandlesHistoryRepository.cs
+++ b/src/Lykke.Job.CandleHistoryWriter.Repositories/Candles/CandlesHistoryRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AzureStorage;
 using AzureStorage.Tables;
@@ -129,6 +130,11 @@ namespace Lykke.Job.CandleHistoryWriter.Repositories.Candles
             storage.GetDataAsync(assetPairId, "1900-01-01").Wait();
 
             return storage;
+        }
+
+        public IReadOnlyList<string> GetStoredAssetPairs()
+        {
+            return _assetConnectionStrings.CurrentValue.Keys.ToList();
         }
     }
 }

--- a/src/Lykke.Job.CandlesHistoryWriter.Core/Domain/Candles/ICandlesHistoryRepository.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Core/Domain/Candles/ICandlesHistoryRepository.cs
@@ -11,5 +11,6 @@ namespace Lykke.Job.CandlesHistoryWriter.Core.Domain.Candles
         Task<IEnumerable<ICandle>> GetCandlesAsync(string assetPairId, CandleTimeInterval interval, CandlePriceType priceType, DateTime @from, DateTime to);
         bool CanStoreAssetPair(string assetPairId);
         Task<ICandle> TryGetFirstCandleAsync(string assetPairId, CandleTimeInterval interval, CandlePriceType priceType);
+        IReadOnlyList<string> GetStoredAssetPairs();
     }
 }

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Common;
+using Common.Log;
+using JetBrains.Annotations;
+using Lykke.Job.CandlesHistoryWriter.Core.Domain.Candles;
+using Lykke.Job.CandlesProducer.Contract;
+using Lykke.SettingsReader;
+using StackExchange.Redis;
+
+namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
+{
+    [UsedImplicitly]
+    public class RedisCacheTruncator : TimerPeriod
+    {
+        private readonly IDatabase _database;
+        private readonly int _amountOfCandlesToStore;
+
+        private readonly List<string> _cacheKeys;
+
+        public RedisCacheTruncator(
+            IReloadingManager<Dictionary<string, string>> assetConnectionStrings,
+            IDatabase database,
+            MarketType market,
+            TimeSpan cacheCleanupPeriod, 
+            int amountOfCandlesToStore,
+            ILog log)
+            : base(nameof(QueueMonitor), (int)cacheCleanupPeriod.TotalMilliseconds, log)
+        {
+            _database = database;
+            _amountOfCandlesToStore = amountOfCandlesToStore;
+
+            var priceTypes = Enum.GetValues(typeof(CandlePriceType));
+            var timeIntervals = Enum.GetValues(typeof(CandleTimeInterval));
+
+            _cacheKeys = new List<string>();
+
+            foreach (var assetId in assetConnectionStrings.CurrentValue.Keys)
+            {
+                foreach (var priceType in priceTypes)
+                {
+                    foreach (var timeInterval in timeIntervals)
+                    {
+                        var keyToTest = $"CandlesHistory:{market}:{assetId}:{priceType}:{timeInterval}";
+                        if (_database.KeyExists(keyToTest)) _cacheKeys.Add(keyToTest);
+                    }
+                }
+            }
+        }
+
+        public override async Task Execute()
+        {
+            foreach (var key in _cacheKeys)
+                await _database.SortedSetRemoveRangeByRankAsync(key, 0, -_amountOfCandlesToStore - 1);
+        }
+    }
+}

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Common;
 using Common.Log;
 using JetBrains.Annotations;
 using Lykke.Job.CandlesHistoryWriter.Core.Domain.Candles;
-using Lykke.SettingsReader;
 using StackExchange.Redis;
 
 namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
@@ -13,21 +11,21 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
     [UsedImplicitly]
     public class RedisCacheTruncator : TimerPeriod
     {
-        private readonly IReloadingManager<Dictionary<string, string>> _assetConnectionStrings;
+        private readonly ICandlesHistoryRepository _historyRepository;
         private readonly IDatabase _database;
         private readonly MarketType _market;
         private readonly int _amountOfCandlesToStore;
 
         public RedisCacheTruncator(
-            IReloadingManager<Dictionary<string, string>> assetConnectionStrings,
+            ICandlesHistoryRepository historyRepository,
             IDatabase database,
             MarketType market,
             TimeSpan cacheCleanupPeriod, 
             int amountOfCandlesToStore,
             ILog log)
-            : base(nameof(QueueMonitor), (int)cacheCleanupPeriod.TotalMilliseconds, log)
+            : base(nameof(RedisCacheTruncator), (int)cacheCleanupPeriod.TotalMilliseconds, log)
         {
-            _assetConnectionStrings = assetConnectionStrings;
+            _historyRepository = historyRepository;
             _database = database;
             _market = market;
             _amountOfCandlesToStore = amountOfCandlesToStore;
@@ -35,13 +33,13 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
 
         public override async Task Execute()
         {
-            foreach (var assetId in _assetConnectionStrings.CurrentValue.Keys)
+            foreach (var assetId in _historyRepository.GetStoredAssetPairs())
             {
                 foreach (var priceType in Constants.StoredPriceTypes)
                 {
                     foreach (var timeInterval in Constants.StoredIntervals)
                     {
-                        await _database.SortedSetRemoveRangeByRankAsync($"CandlesHistory:{_market}:{assetId}:{priceType}:{timeInterval}", 0, -_amountOfCandlesToStore - 1);
+                        await _database.SortedSetRemoveRangeByRankAsync(RedisCandlesCacheService.GetKey(_market, assetId, priceType, timeInterval), 0, -_amountOfCandlesToStore - 1);
                     }
                 }
             }

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
@@ -72,7 +72,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
 
             // TODO: This is non concurrent-safe update
 
-            var key = GetKey(assetPairId, priceType, timeInterval);
+            var key = GetKey(_market, assetPairId, priceType, timeInterval);
 
             // Cleans cache
 
@@ -92,7 +92,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
         {
             // TODO: This is non concurrent-safe method
 
-            var key = GetKey(candle.AssetPairId, candle.PriceType, candle.TimeInterval);
+            var key = GetKey(_market, candle.AssetPairId, candle.PriceType, candle.TimeInterval);
             var serializedValue = SerializeCandle(candle);
 
             // Transaction is needed here, despite of this method is non concurrent-safe,
@@ -125,7 +125,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
 
         public async Task<IEnumerable<ICandle>> GetCandlesAsync(string assetPairId, CandlePriceType priceType, CandleTimeInterval timeInterval, DateTime fromMoment, DateTime toMoment)
         {
-            var key = GetKey(assetPairId, priceType, timeInterval);
+            var key = GetKey(_market, assetPairId, priceType, timeInterval);
             var from = fromMoment.ToString(TimestampFormat);
             var to = toMoment.ToString(TimestampFormat);
             var serializedValues = await _database.SortedSetRangeByValueAsync(key, from, to, Exclude.Stop);
@@ -196,9 +196,9 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
             }
         }
 
-        private string GetKey(string assetPairId, CandlePriceType priceType, CandleTimeInterval timeInterval)
+        public static string GetKey(MarketType market, string assetPairId, CandlePriceType priceType, CandleTimeInterval timeInterval)
         {
-            return $"CandlesHistory:{_market}:{assetPairId}:{priceType}:{timeInterval}";
+            return $"CandlesHistory:{market}:{assetPairId}:{priceType}:{timeInterval}";
         }
     }
 }

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Autofac;
 using Common;
 using JetBrains.Annotations;
 using Lykke.Job.CandlesProducer.Contract;
@@ -20,19 +21,24 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
     /// Caches candles in the redis using lexographical indexes with candles data as the auxiliary information of the index
     /// </summary>
     [UsedImplicitly]
-    public class RedisCandlesCacheService : ICandlesCacheService
+    public class RedisCandlesCacheService : ICandlesCacheService, IStartable, IStopable
     {
         private const string TimestampFormat = "yyyyMMddHHmmss";
 
         private readonly IDatabase _database;
         private readonly MarketType _market;
         private readonly int _amountOfCandlesToStore;
+        private readonly TimeSpan _cacheCleanupPeriod;
+        private DateTime _lastCleanupTime;
 
-        public RedisCandlesCacheService(IDatabase database, MarketType market, int amountOfCandlesToStore)
+        public RedisCandlesCacheService(IDatabase database, MarketType market, int amountOfCandlesToStore, TimeSpan cacheCleanupPeriod)
         {
             _database = database;
             _market = market;
             _amountOfCandlesToStore = amountOfCandlesToStore;
+            _cacheCleanupPeriod = cacheCleanupPeriod;
+
+            _lastCleanupTime = DateTime.UtcNow;
         }
 
         public IImmutableDictionary<string, IImmutableList<ICandle>> GetState()
@@ -96,6 +102,9 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
 
             var key = GetKey(candle.AssetPairId, candle.PriceType, candle.TimeInterval);
             var serializedValue = SerializeCandle(candle);
+            
+            // Peek the top candle from cache
+            var candleOnTop = DeserializeCandle(_database.ListGetByIndex(key, -1), null, CandlePriceType.Unspecified, CandleTimeInterval.Unspecified);
 
             // Transaction is needed here, despite of this method is non concurrent-safe,
             // without transaction at the moment candle can be missed or doubled
@@ -103,33 +112,24 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
 
             var transaction = _database.CreateTransaction();
 
-            // Removes old candle
-
-            var currentCandleKey = candle.Timestamp.ToString(TimestampFormat);
-            var nextCandleKey = candle.Timestamp.AddIntervalTicks(1, candle.TimeInterval).ToString(TimestampFormat);
-
-            var candleRemovalTask = transaction.SortedSetRemoveRangeByValueAsync(key, currentCandleKey, nextCandleKey, Exclude.Stop);
+            // If the top candle is the current one, we need to remove it first, and then add once again with updated content.
+            // This is important because we may have several candle updates during its time interval.
+            if (DateTime.UtcNow.TruncateTo(candle.TimeInterval).CompareTo(candleOnTop.Timestamp) == 0)
+                await transaction.SortedSetRemoveRangeByRankAsync(key, -1, -1);
 
             // Adds new candle
-
-            var candleAdditionTask = transaction.SortedSetAddAsync(key, serializedValue, 0);
+            await transaction.SortedSetAddAsync(key, serializedValue, 0);
 
             if (!await transaction.ExecuteAsync())
             {
                 throw new InvalidOperationException("Redis transaction is rolled back");
             }
 
-            // Operations in the transaction can't be awaited before transaction is executed, so
-            // saves tasks and waits they here, just to calm down the Resharper
-
-            await Task.WhenAll(candleRemovalTask, candleAdditionTask);
-
-            // Truncates candles set to the _amountOfCandlesToStore. 
-            // The older candles will be removed, since they goes first in the set
-
-            // TODO: Do it not on every candle
-
-            await _database.SortedSetRemoveRangeByRankAsync(key, 0, -_amountOfCandlesToStore - 1);
+            if (_lastCleanupTime.Add(_cacheCleanupPeriod) >= DateTime.UtcNow)
+            {
+                await _database.SortedSetRemoveRangeByRankAsync(key, 0, -_amountOfCandlesToStore - 1);
+                _lastCleanupTime = DateTime.UtcNow;
+            }
         }
 
         public async Task<IEnumerable<ICandle>> GetCandlesAsync(string assetPairId, CandlePriceType priceType, CandleTimeInterval timeInterval, DateTime fromMoment, DateTime toMoment)
@@ -208,6 +208,21 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
         private string GetKey(string assetPairId, CandlePriceType priceType, CandleTimeInterval timeInterval)
         {
             return $"CandlesHistory:{_market}:{assetPairId}:{priceType}:{timeInterval}";
+        }
+
+        public void Start()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            // do nothing
+        }
+
+        public void Stop()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCandlesCacheService.cs
@@ -27,7 +27,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
         private readonly IDatabase _database;
         private readonly MarketType _market;
 
-        public RedisCandlesCacheService(IDatabase database, MarketType market, int amountOfCandlesToStore, TimeSpan cacheCleanupPeriod)
+        public RedisCandlesCacheService(IDatabase database, MarketType market)
         {
             _database = database;
             _market = market;

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Settings/CandlesHistoryWriterSettings.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Settings/CandlesHistoryWriterSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Lykke.Job.CandlesHistoryWriter.Services.Settings
+﻿using System;
+
+namespace Lykke.Job.CandlesHistoryWriter.Services.Settings
 {
     public class CandlesHistoryWriterSettings
     {        
@@ -10,6 +12,6 @@
         public MigrationSettings Migration { get; set; }
         public ErrorManagementSettings ErrorManagement { get; set; }
         public int HistoryTicksCacheSize { get; set; }
-        public int MaxCandlesCountWhichCanBeRequested { get; set; }
+        public TimeSpan CacheCleanupPeriod { get; set; }
     }
 }

--- a/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
@@ -178,7 +178,6 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
             builder.RegisterType<RedisCacheTruncator>()
                 .As<IStartable>()
                 .SingleInstance()
-                .WithParameter(TypedParameter.From(_candleHistoryAssetConnections))
                 .WithParameter(TypedParameter.From(_marketType))
                 .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod))
                 .WithParameter(TypedParameter.From(_settings.HistoryTicksCacheSize))

--- a/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
@@ -149,8 +149,6 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
             builder.RegisterType<RedisCandlesCacheService>()
                 .As<ICandlesCacheService>()
                 .WithParameter(TypedParameter.From(_marketType))
-                .WithParameter(TypedParameter.From(_settings.HistoryTicksCacheSize))
-                .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod))
                 .SingleInstance();
 
             builder.RegisterType<CandlesPersistenceManager>()
@@ -176,6 +174,15 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
             builder.RegisterType<CandlesPersistenceQueueSnapshotRepository>()
                 .As<ICandlesPersistenceQueueSnapshotRepository>()
                 .WithParameter(TypedParameter.From(AzureBlobStorage.Create(_dbSettings.ConnectionString(x => x.SnapshotsConnectionString), TimeSpan.FromMinutes(10))));
+
+            builder.RegisterType<RedisCacheTruncator>()
+                .As<IStartable>()
+                .SingleInstance()
+                .WithParameter(TypedParameter.From(_candleHistoryAssetConnections))
+                .WithParameter(TypedParameter.From(_marketType))
+                .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod))
+                .WithParameter(TypedParameter.From(_settings.HistoryTicksCacheSize))
+                .AutoActivate();
 
             RegisterCandlesMigration(builder);
         }

--- a/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
@@ -150,6 +150,7 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
                 .As<ICandlesCacheService>()
                 .WithParameter(TypedParameter.From(_marketType))
                 .WithParameter(TypedParameter.From(_settings.HistoryTicksCacheSize))
+                .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod))
                 .SingleInstance();
 
             builder.RegisterType<CandlesPersistenceManager>()

--- a/tests/Lykke.Job.CandlesHistoryWriter.Tests/CachedCandlesCacheServiceTests.cs
+++ b/tests/Lykke.Job.CandlesHistoryWriter.Tests/CachedCandlesCacheServiceTests.cs
@@ -26,7 +26,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Tests
         public void InitializeTest()
         {
             _db = (new Mock<IDatabase>()).Object;
-            _service = new RedisCandlesCacheService(_db, Core.Domain.Candles.MarketType.Mt, AmountOfCandlesToStore);
+            _service = new RedisCandlesCacheService(_db, Core.Domain.Candles.MarketType.Mt, AmountOfCandlesToStore, new TimeSpan(0, 0, 1, 0));
         }
 
 

--- a/tests/Lykke.Job.CandlesHistoryWriter.Tests/CachedCandlesCacheServiceTests.cs
+++ b/tests/Lykke.Job.CandlesHistoryWriter.Tests/CachedCandlesCacheServiceTests.cs
@@ -17,8 +17,6 @@ namespace Lykke.Job.CandlesHistoryWriter.Tests
     [TestClass]
     public class CachedCandlesCacheServiceTests
     {
-        private const int AmountOfCandlesToStore = 5;
-
         private ICandlesCacheService _service;
         private IDatabase _db;
 
@@ -26,7 +24,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Tests
         public void InitializeTest()
         {
             _db = (new Mock<IDatabase>()).Object;
-            _service = new RedisCandlesCacheService(_db, Core.Domain.Candles.MarketType.Mt, AmountOfCandlesToStore, new TimeSpan(0, 0, 1, 0));
+            _service = new RedisCandlesCacheService(_db, Core.Domain.Candles.MarketType.Mt);
         }
 
 


### PR DESCRIPTION
Adding and removing candlet to\from cache one by one turned out to be rather slow. It's needed to speed up the process. Moved redis cache cleanup to a separate thread and introduced a time-out for this operation.